### PR TITLE
Extracting exception serializer logic

### DIFF
--- a/Source/Otc.ExceptionHandling.Abstractions/IExceptionHandlerConfiguration.cs
+++ b/Source/Otc.ExceptionHandling.Abstractions/IExceptionHandlerConfiguration.cs
@@ -1,7 +1,5 @@
-﻿using Otc.ExceptionHandling.Abstractions;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Otc.ExceptionHandling.Abstractions
 {
@@ -11,6 +9,11 @@ namespace Otc.ExceptionHandling.Abstractions
         /// Registered events on configuration
         /// </summary>
         List<IExceptionHandlerEvent> Events { get; }
+
+        /// <summary>
+        /// Lambda function that returns an instance of <see cref="IExceptionSerializer"/>.
+        /// </summary>
+        Func<IExceptionSerializer> Serializer { get; }
 
         /// <summary>
         /// Validate if there is configuration for specific exceptions on exception handling setup

--- a/Source/Otc.ExceptionHandling.Abstractions/IExceptionHandlerConfigurationExpression.cs
+++ b/Source/Otc.ExceptionHandling.Abstractions/IExceptionHandlerConfigurationExpression.cs
@@ -1,8 +1,5 @@
-﻿using Otc.ExceptionHandling.Abstractions;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Otc.ExceptionHandling.Abstractions
 {
@@ -38,7 +35,7 @@ namespace Otc.ExceptionHandling.Abstractions
         /// Expose - Log and returns the entire exception.
         /// Suppress - Log and returns only the base exception.
         /// Ignore - Ignore the entire exception.</param>
-        IExceptionHandlerConfigurationExpression ForException<TException>(int statusCode, ExceptionHandlerBehavior behavior = ExceptionHandlerBehavior.ClientError) 
+        IExceptionHandlerConfigurationExpression ForException<TException>(int statusCode, ExceptionHandlerBehavior behavior = ExceptionHandlerBehavior.ClientError)
             where TException : Exception;
 
         /// <summary>
@@ -52,5 +49,11 @@ namespace Otc.ExceptionHandling.Abstractions
         /// Ignore - Ignore the entire exception.</param>
         IExceptionHandlerConfigurationExpression ForException(Type exception, int statusCode, ExceptionHandlerBehavior behavior = ExceptionHandlerBehavior.ClientError);
 
+        /// <summary>
+        /// Lambda function that returns an instance of <see cref="IExceptionSerializer"/>
+        /// to be used in output serialization.
+        /// </summary>
+        /// <param name="serializer">Lambda that returns <see cref="IExceptionSerializer"/> instance</param>
+        IExceptionHandlerConfigurationExpression SetSerializer(Func<IExceptionSerializer> serializer);
     }
 }

--- a/Source/Otc.ExceptionHandling.Abstractions/IExceptionSerializer.cs
+++ b/Source/Otc.ExceptionHandling.Abstractions/IExceptionSerializer.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Otc.ExceptionHandling.Abstractions
+{
+    public interface IExceptionSerializer
+    {
+        Task<string> SerializeAsync(object output, HttpContext httpContext);
+    }
+}

--- a/Source/Otc.ExceptionHandling.Abstractions/Otc.ExceptionHandling.Abstractions.csproj
+++ b/Source/Otc.ExceptionHandling.Abstractions/Otc.ExceptionHandling.Abstractions.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <VersionPrefix>3.1.2</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-exception-handling</PackageProjectUrl>
     <Authors>Ole Consignado</Authors>
     <Company>Ole Consignado</Company>

--- a/Source/Otc.ExceptionHandling.Tests/ExceptionHandlerSerializerTest.cs
+++ b/Source/Otc.ExceptionHandling.Tests/ExceptionHandlerSerializerTest.cs
@@ -84,8 +84,9 @@ namespace Otc.ExceptionHandling.Tests
 
             var httpContext = CreateHttpContext(output =>
             {
-                Assert.Matches("\\{\\\r\\\n  \"logEntryId\": " +
-                    "\"[0-9a-f\\-]{36}\",\\\r\\\n  \"exception\": null\\\r\\\n\\}", output);
+                output = output.Replace("\r", string.Empty);
+                Assert.Matches("\\{\\\n  \"logEntryId\": " +
+                    "\"[0-9a-f\\-]{36}\",\\\n  \"exception\": null\\\n\\}", output);
             });
 
             await exceptionHandler.HandleExceptionAsync(new NullReferenceException(), httpContext);
@@ -102,8 +103,9 @@ namespace Otc.ExceptionHandling.Tests
 
             var httpContext = CreateHttpContext(output =>
             {
-                Assert.Equal("{\r\n  \"key\": \"DomainException\",\r\n" +
-                    "  \"errors\": [],\r\n  \"message\": \"erro\"\r\n}", output);
+                output = output.Replace("\r", string.Empty);
+                Assert.Equal("{\n  \"key\": \"DomainException\",\n" +
+                    "  \"errors\": [],\n  \"message\": \"erro\"\n}", output);
 
             });
 
@@ -122,8 +124,9 @@ namespace Otc.ExceptionHandling.Tests
 
             var httpContext = CreateHttpContext(output =>
             {
-                Assert.Matches("\\{\\\r\\\n  \"logEntryId\": " +
-                    "\"[0-9a-f\\-]{36}\",\\\r\\\n  \"exception\": null\\\r\\\n\\}", output);
+                output = output.Replace("\r", string.Empty);
+                Assert.Matches("\\{\\\n  \"logEntryId\": " +
+                    "\"[0-9a-f\\-]{36}\",\\\n  \"exception\": null\\\n\\}", output);
             });
 
             var statusCode = await exceptionHandler

--- a/Source/Otc.ExceptionHandling.Tests/ExceptionHandlerSerializerTest.cs
+++ b/Source/Otc.ExceptionHandling.Tests/ExceptionHandlerSerializerTest.cs
@@ -1,0 +1,168 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Otc.DomainBase.Exceptions;
+using Otc.ExceptionHandling.Abstractions;
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Otc.ExceptionHandling.Tests
+{
+    public class ExceptionHandlerSerializerTest
+    {
+        IServiceProvider serviceProvider;
+        private IExceptionHandler CreateExceptionHandler(
+            Action<IServiceCollection> configuration = null)
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddExceptionHandling();
+            configuration?.Invoke(serviceCollection);
+            serviceCollection.AddScoped<ILoggerFactory>(ctx => new LoggerFactory());
+            serviceProvider = serviceCollection.BuildServiceProvider();
+            return serviceProvider.GetRequiredService<IExceptionHandler>();
+        }
+
+        private HttpContext CreateHttpContext(Action<string> asserts)
+        {
+            var httpContextMock = new Mock<HttpContext>();
+            var response = new Mock<Response>();
+
+            response.Setup(_ => _.Body.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(),
+                It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Callback((byte[] data, int offset, int length, CancellationToken token) =>
+                    asserts(Encoding.UTF8.GetString(data)))
+                .Returns(() => Task.CompletedTask);
+
+            response.SetupSet(p => p.StatusCode = It.IsAny<int>())
+                .Callback<int>(c => response.SetupGet(p => p.StatusCode).Returns(c));
+
+            httpContextMock.Setup(x => x.Response).Returns(() => response.Object);
+
+            return httpContextMock.Object;
+        }
+
+        [Fact]
+        public async Task Default_Serializer_ServerError_Success()
+        {
+            var exceptionHandler = CreateExceptionHandler();
+
+            var httpContext = CreateHttpContext(output =>
+            {
+                Assert.Matches("\\{\"logEntryId\":\"[0-9a-f\\-]{36}\"\\}", output);
+            });
+
+            await exceptionHandler.HandleExceptionAsync(new NullReferenceException(), httpContext);
+        }
+
+        [Fact]
+        public async Task Default_Serializer_ClientError_Success()
+        {
+            var exceptionHandler = CreateExceptionHandler();
+
+            var httpContext = CreateHttpContext(output =>
+            {
+                Assert.Contains("{\"key\":\"DomainException\"," +
+                    "\"errors\":[],\"message\":\"erro\"}", output);
+            });
+
+            await exceptionHandler.HandleExceptionAsync(new CustomCoreException(), httpContext);
+        }
+
+        [Fact]
+        public async Task Custom_Serializer_ServerError_Success()
+        {
+            var exceptionHandler = CreateExceptionHandler(sc =>
+            {
+                sc.AddExceptionHandlingConfiguration(config =>
+                    config.SetSerializer(() => new CustomExceptionSerializer()));
+            });
+
+            var httpContext = CreateHttpContext(output =>
+            {
+                Assert.Matches("\\{\\\r\\\n  \"logEntryId\": " +
+                    "\"[0-9a-f\\-]{36}\",\\\r\\\n  \"exception\": null\\\r\\\n\\}", output);
+            });
+
+            await exceptionHandler.HandleExceptionAsync(new NullReferenceException(), httpContext);
+        }
+
+        [Fact]
+        public async Task Custom_Serializer_ClientError_Success()
+        {
+            var exceptionHandler = CreateExceptionHandler(sc =>
+            {
+                sc.AddExceptionHandlingConfiguration(config =>
+                    config.SetSerializer(() => new CustomExceptionSerializer()));
+            });
+
+            var httpContext = CreateHttpContext(output =>
+            {
+                Assert.Equal("{\r\n  \"key\": \"DomainException\",\r\n" +
+                    "  \"errors\": [],\r\n  \"message\": \"erro\"\r\n}", output);
+
+            });
+
+            await exceptionHandler.HandleExceptionAsync(new CustomCoreException(), httpContext);
+        }
+
+        [Fact]
+        public async Task Custom_Serializer_ClientError_WithEvent_Success()
+        {
+            var exceptionHandler = CreateExceptionHandler(sc =>
+            {
+                sc.AddExceptionHandlingConfiguration(config =>
+                    config.SetSerializer(() => new CustomExceptionSerializer())
+                        .AddEvent<CustomEvent>());
+            });
+
+            var httpContext = CreateHttpContext(output =>
+            {
+                Assert.Matches("\\{\\\r\\\n  \"logEntryId\": " +
+                    "\"[0-9a-f\\-]{36}\",\\\r\\\n  \"exception\": null\\\r\\\n\\}", output);
+            });
+
+            var statusCode = await exceptionHandler
+                .HandleExceptionAsync(new CustomCoreException(), httpContext);
+
+            Assert.Equal(200, statusCode);
+        }
+    }
+
+    public class CustomCoreException : CoreException
+    {
+        public CustomCoreException() : base("erro")
+        {
+        }
+        public override string Key => "DomainException";
+    }
+
+    public class CustomExceptionSerializer : ExceptionSerializer
+    {
+        protected override JsonSerializerSettings GetJsonSerializerSettings()
+        {
+            var settings = base.GetJsonSerializerSettings();
+            settings.Formatting = Formatting.Indented;
+            settings.NullValueHandling = NullValueHandling.Include;
+            return settings;
+        }
+    }
+
+    public class CustomEvent : IExceptionHandlerEvent
+    {
+        public (int statusCode, Exception exception, ExceptionHandlerBehavior behavior)
+            Intercept(int statusCode, Exception exception)
+        {
+            return (200, new Exception("custom"), ExceptionHandlerBehavior.ServerError);
+        }
+
+        public bool IsElegible(int statusCode, Exception exception)
+        {
+            return exception is CustomCoreException;
+        }
+    }
+}

--- a/Source/Otc.ExceptionHandling/ExceptionHandlerConfiguration.cs
+++ b/Source/Otc.ExceptionHandling/ExceptionHandlerConfiguration.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Otc.ExceptionHandling
 {
@@ -19,6 +18,8 @@ namespace Otc.ExceptionHandling
 
         public List<IExceptionHandlerEvent> Events { get; }
 
+        public Func<IExceptionSerializer> Serializer { get; private set; }
+
         public bool HasBehaviors => behaviors.Any();
 
         public ForExceptionBehavior ValidateBehavior(Exception ex)
@@ -31,7 +32,7 @@ namespace Otc.ExceptionHandling
 
             return null;
         }
-        
+
         private void Build(Action<IExceptionHandlerConfigurationExpression> action)
         {
             var configurationExpression = new ExceptionHandlerConfigurationExpression();
@@ -41,6 +42,8 @@ namespace Otc.ExceptionHandling
             this.Events.AddRange(configurationExpression.Events);
 
             this.behaviors = new Dictionary<Type, ForExceptionBehavior>(configurationExpression.Behaviors);
+
+            this.Serializer = configurationExpression.Serializer;
         }
     }
 }

--- a/Source/Otc.ExceptionHandling/ExceptionHandlerConfigurationExpression.cs
+++ b/Source/Otc.ExceptionHandling/ExceptionHandlerConfigurationExpression.cs
@@ -1,8 +1,6 @@
 ﻿using Otc.ExceptionHandling.Abstractions;
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Otc.ExceptionHandling
 {
@@ -12,11 +10,14 @@ namespace Otc.ExceptionHandling
         {
             Events = new List<IExceptionHandlerEvent>();
             Behaviors = new Dictionary<Type, ForExceptionBehavior>();
+            Serializer = () => new ExceptionSerializer();
         }
 
         public List<IExceptionHandlerEvent> Events { get; }
 
         public Dictionary<Type, ForExceptionBehavior> Behaviors { get; }
+
+        public Func<IExceptionSerializer> Serializer { get; private set; }
 
         public IExceptionHandlerConfigurationExpression AddEvent(IExceptionHandlerEvent @event)
         {
@@ -38,6 +39,13 @@ namespace Otc.ExceptionHandling
         public IExceptionHandlerConfigurationExpression ForException(Type exception, int statusCode, ExceptionHandlerBehavior behavior = ExceptionHandlerBehavior.ClientError)
         {
             Behaviors.Add(exception, new ForExceptionBehavior() { StatusCode = statusCode, Behavior = behavior });
+
+            return this;
+        }
+
+        public IExceptionHandlerConfigurationExpression SetSerializer(Func<IExceptionSerializer> serializer)
+        {
+            Serializer = serializer;
 
             return this;
         }

--- a/Source/Otc.ExceptionHandling/ExceptionSerializer.cs
+++ b/Source/Otc.ExceptionHandling/ExceptionSerializer.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Otc.ExceptionHandling.Abstractions;
+using System;
+using System.Threading.Tasks;
+
+namespace Otc.ExceptionHandling
+{
+    public class ExceptionSerializer : IExceptionSerializer
+    {
+        public Task<string> SerializeAsync(object output, HttpContext httpContext)
+        {
+            var jsonSerializerSettings = GetJsonSerializerSettings();
+            jsonSerializerSettings.ContractResolver = GetContractResolver();
+            var message = JsonConvert.SerializeObject(output, jsonSerializerSettings);
+
+            return Task.FromResult(message);
+        }
+
+        protected virtual JsonSerializerSettings GetJsonSerializerSettings()
+        {
+            return new JsonSerializerSettings()
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                NullValueHandling = NullValueHandling.Ignore,
+                MaxDepth = 10,
+                Formatting = IsDevelopmentEnvironment() ? Formatting.Indented : Formatting.None
+            };
+        }
+
+        protected virtual CamelCasePropertyNamesContractResolver GetContractResolver()
+        {
+            return new CoreExceptionJsonContractResolver()
+            {
+                IgnoreSerializableInterface = true
+            };
+        }
+
+        protected bool IsDevelopmentEnvironment()
+            => Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
+    }
+}

--- a/Source/Otc.ExceptionHandling/Otc.ExceptionHandling.csproj
+++ b/Source/Otc.ExceptionHandling/Otc.ExceptionHandling.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <VersionPrefix>3.1.2</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-exception-handling</PackageProjectUrl>
     <Authors>Ole Consignado</Authors>
     <Company>Ole Consignado</Company>

--- a/Source/Otc.Mvc.Filters/Otc.Mvc.Filters.csproj
+++ b/Source/Otc.Mvc.Filters/Otc.Mvc.Filters.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <VersionPrefix>3.1.2</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-exception-handling</PackageProjectUrl>
     <Authors>Ole Consignado</Authors>
     <Company>Ole Consignado</Company>

--- a/Source/Otc.SwaggerSchemaFiltering/Otc.SwaggerSchemaFiltering.csproj
+++ b/Source/Otc.SwaggerSchemaFiltering/Otc.SwaggerSchemaFiltering.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <VersionPrefix>3.1.2</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-exception-handling</PackageProjectUrl>
     <Authors>Ole Consignado</Authors>
     <Company>Ole Consignado</Company>


### PR DESCRIPTION
- Extracting exception serialization logic to allow consumers to inject their own serializer.

- Example use case is exception encryption, delaying encryption logic to the last step, which is serialization, when exception content has already being logged, for instance.